### PR TITLE
Added support for VS2015

### DIFF
--- a/jQueryCodeSnippets/source.extension.vsixmanifest
+++ b/jQueryCodeSnippets/source.extension.vsixmanifest
@@ -12,9 +12,9 @@
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="11.0" />
         <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="12.0" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="14.0" />
     </Installation>
     <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="registry.pkgdef" />


### PR DESCRIPTION
I've removed the dependency on the .NET Framework since it's irrelevant for shipping snippets.

This pull requests fixes bug #14 