### PR TITLE
Removed type="text/javascript"

### DIFF
--- a/jQueryCodeSnippets/HTML/jQuery/jq.snippet
+++ b/jQueryCodeSnippets/HTML/jQuery/jq.snippet
@@ -12,7 +12,7 @@
       <Shortcut>jq</Shortcut>
     </Header>
     <Snippet>
-      <Code Language="html"><![CDATA[<script type="text/javascript">
+      <Code Language="html"><![CDATA[<script>
     $$(function() {
         $end$ 
     });

--- a/jQueryCodeSnippets/HTML/jQuery/jqScript.snippet
+++ b/jQueryCodeSnippets/HTML/jQuery/jqScript.snippet
@@ -21,7 +21,7 @@
           </Function>
         </Literal>
       </Declarations>
-      <Code Language="html"><![CDATA[<script type="text/javascript" src="$path$"></script>
+      <Code Language="html"><![CDATA[<script src="$path$"></script>
 $end$]]></Code>
     </Snippet>
   </CodeSnippet>

--- a/jQueryCodeSnippets/HTML/jQuery/jqScriptCdnGoogle.snippet
+++ b/jQueryCodeSnippets/HTML/jQuery/jqScriptCdnGoogle.snippet
@@ -21,7 +21,7 @@
           </Function>
         </Literal>
       </Declarations>
-      <Code Language="html"><![CDATA[<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/$version$/jquery.min.js"></script>
+      <Code Language="html"><![CDATA[<script src="//ajax.googleapis.com/ajax/libs/jquery/$version$/jquery.min.js"></script>
 $end$]]></Code>
     </Snippet>
   </CodeSnippet>

--- a/jQueryCodeSnippets/HTML/jQuery/jqScriptCdnMs.snippet
+++ b/jQueryCodeSnippets/HTML/jQuery/jqScriptCdnMs.snippet
@@ -21,7 +21,7 @@
           </Function>
         </Literal>
       </Declarations>
-      <Code Language="html"><![CDATA[<script type="text/javascript" src="//ajax.aspnetcdn.com/ajax/jQuery/jquery-$version$.min.js"></script>
+      <Code Language="html"><![CDATA[<script src="//ajax.aspnetcdn.com/ajax/jQuery/jquery-$version$.min.js"></script>
 $end]]></Code>
     </Snippet>
   </CodeSnippet>

--- a/jQueryCodeSnippets/HTML/jQuery/jqScriptMin.snippet
+++ b/jQueryCodeSnippets/HTML/jQuery/jqScriptMin.snippet
@@ -21,7 +21,7 @@
           </Function>
         </Literal>
       </Declarations>
-      <Code Language="html"><![CDATA[<script type="text/javascript" src="$path$">
+      <Code Language="html"><![CDATA[<script src="$path$">
     $$(function() {
         $end$ 
     });

--- a/jQueryCodeSnippets/HTML/jQuery/jqScriptUiCdnGoogle.snippet
+++ b/jQueryCodeSnippets/HTML/jQuery/jqScriptUiCdnGoogle.snippet
@@ -21,7 +21,7 @@
           </Function>
         </Literal>
       </Declarations>
-      <Code Language="html"><![CDATA[<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/$version$/jquery-ui.min.js"></script>
+      <Code Language="html"><![CDATA[<script src="//ajax.googleapis.com/ajax/libs/jqueryui/$version$/jquery-ui.min.js"></script>
 $end$]]></Code>
     </Snippet>
   </CodeSnippet>

--- a/jQueryCodeSnippets/HTML/jQuery/jqScriptValidateCdnMs.snippet
+++ b/jQueryCodeSnippets/HTML/jQuery/jqScriptValidateCdnMs.snippet
@@ -21,7 +21,7 @@
           </Function>
         </Literal>
       </Declarations>
-      <Code Language="html"><![CDATA[<script type="text/javascript" src="//ajax.aspnetcdn.com/ajax/jquery.validate/$version$/jquery.validate.min.js"></script>
+      <Code Language="html"><![CDATA[<script src="//ajax.aspnetcdn.com/ajax/jquery.validate/$version$/jquery.validate.min.js"></script>
 $end$]]></Code>
     </Snippet>
   </CodeSnippet>

--- a/jQueryCodeSnippets/HTML/jQuery/jqScriptValidateUnobtrusiveCdnMs.snippet
+++ b/jQueryCodeSnippets/HTML/jQuery/jqScriptValidateUnobtrusiveCdnMs.snippet
@@ -21,7 +21,7 @@
           </Function>
         </Literal>
       </Declarations>
-      <Code Language="html"><![CDATA[<script type="text/javascript" src="//ajax.aspnetcdn.com/ajax/mvc/$version$/jquery.validate.unobtrusive.min.js"></script>
+      <Code Language="html"><![CDATA[<script src="//ajax.aspnetcdn.com/ajax/mvc/$version$/jquery.validate.unobtrusive.min.js"></script>
 $end$]]></Code>
     </Snippet>
   </CodeSnippet>


### PR DESCRIPTION
Removed type="text/javascript" on &lt;script&gt; tags since that's no longer
required in modern browsers.